### PR TITLE
Fix to be able to specify the maximum file upload size

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -13,5 +13,7 @@ EXPOSE 8080
 # Port for SSH access to git repository (Optional)
 EXPOSE 29418
 
-CMD ["java", "-jar", "/opt/gitbucket.war"]
+ENV MAX_FILE_SIZE=3145728
+
+CMD ["sh", "-c", "java -jar /opt/gitbucket.war --max_file_size=$MAX_FILE_SIZE"]
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ You can also specify the data directory by `-v` option:
 ```
 docker run -d -p 8080:8080 -v `pwd`/gitbucket:/gitbucket gitbucket/gitbucket
 ```
+
+You can specify an uploadable file size using the environment variable (MAX_FILE_SIZE).
+To set 10MB, proceed as follows.
+
+```
+docker run -d -p 8080:8080 -e MAX_FILE_SIZE=10485760 gitbucket/gitbucket
+```


### PR DESCRIPTION
Fix to be able to set `--max_file_size` by passing environment variable (MAX_FILE_SIZE).
