### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: build
+name: nightly build
 
 on:
   schedule:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,5 +46,5 @@ jobs:
         
     - name: Push Docker image to Docker Hub
       run: |
-        docker login -u {{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
         docker push gitbucket/gitbucket:nightly

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-gitbucket-docker
+gitbucket-docker ![default build](https://github.com/gitbucket/gitbucket-docker/workflows/default%20build/badge.svg) ![nightly build](https://github.com/gitbucket/gitbucket-docker/workflows/nightly%20build/badge.svg)
 ========
 Docker image of GitBucket which is an open source GitHub server powered by Scala
 


### PR DESCRIPTION
fix for #24 

plus
- also added status badge to README.md
- nightly build work flow name was just `build`, so changed to `nighly build`. thus status badge for nightly build does not exists and will show up at next build.