### PR TITLE
support multi-arch image

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-    tags:        
+    tags:
       - '*'
 
 jobs:
@@ -14,11 +14,21 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: gitbucket/gitbucket
-          tag_with_ref: true
-          dockerfile: Dockerfile
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            wang1010q/gitbucket

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             wang1010q/gitbucket

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -31,4 +31,4 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
-            wang1010q/gitbucket
+            gitbucket/gitbucket

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk:8-jre-hotspot
 
 LABEL maintainer="Naoki Takezoe <takezoe [at] gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-alpine
 
 LABEL maintainer="Naoki Takezoe <takezoe [at] gmail.com>"
 


### PR DESCRIPTION
1. openjdk:8-jre not support arm arch.
2. openjdk:8-jre-alpine has error
3. use adoptopenjdk:8-jre-hotspot is ok
4. [https://hub.docker.com/repository/docker/wang1010q/gitbucket/general](https://hub.docker.com/repository/docker/wang1010q/gitbucket/general) test is ok.
5. only hotspot support multi arch
6. openj9 only support amd64


**use openjdk:8-jre-alpine** error
```bash
pi@raspbian:~$ docker run -p 8080:8080 -p 29418:29418 wang1010q/gitbucket
2020-12-29 02:37:53.233:INFO::main: Logging initialized @670ms to org.eclipse.jetty.util.log.StdErrLog
2020-12-29 02:37:53.594:WARN:oejsh.ContextHandler:main: Empty contextPath
2020-12-29 02:37:53.614:INFO:oejs.Server:main: jetty-9.4.32.v20200930; built: 2020-09-30T16:16:37.804Z; git: de97d26f7bd222a0e16831e353d702a7a422f711; jvm 1.8.0_212-b04
2020-12-29 02:37:57.734:INFO:oejw.StandardDescriptorProcessor:main: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
2020-12-29 02:37:58.786:INFO:oejs.session:main: DefaultSessionIdManager workerName=node0
2020-12-29 02:37:58.787:INFO:oejs.session:main: No SessionScavenger set, using defaults
2020-12-29 02:37:58.803:INFO:oejs.session:main: node0 Scavenging every 660000ms
02:38:01.180 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
02:38:02.038 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
02:38:02.105 [main] WARN  slick.util.AsyncExecutor - Having maxConnection > maxThreads can result in deadlocks if transactions or database locks are used.
02:38:02.180 [main] INFO  g.core.servlet.InitializeListener - Check version
02:38:02.181 [main] INFO  g.core.servlet.InitializeListener - Start schema update
02:38:05.850 [main] INFO  l.servicelocator.ServiceLocator - Can not use class liquibase.parser.core.json.JsonChangeLogParser as a Liquibase service because org.yaml.snakeyaml.constructor.BaseConstructor is not in the classpath
02:38:05.853 [main] INFO  l.servicelocator.ServiceLocator - Can not use class liquibase.parser.core.yaml.YamlChangeLogParser as a Liquibase service because org.yaml.snakeyaml.constructor.BaseConstructor is not in the classpath
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (assembler_aarch64.hpp:1156), pid=1, tid=0x0000007f915e2aa0
#  guarantee(Rs != Rn && Rs != Rt) failed: unpredictable instruction
#
# JRE version: OpenJDK Runtime Environment (8.0_212-b04) (build 1.8.0_212-b04)
# Java VM: OpenJDK 64-Bit Server VM (25.212-b04 mixed mode linux-aarch64 compressed oops)
# Derivative: IcedTea 3.12.0
# Distribution: Custom build (Sat May  4 17:44:26 UTC 2019)
# Core dump written. Default location: //core or core.1
#
# An error report file with more information is saved as:
# //hs_err_pid1.log
#
# Compiler replay data is saved as:
# //replay_pid1.log
#
# If you would like to submit a bug report, please include
# instructions on how to reproduce the bug and visit:
#   https://icedtea.classpath.org/bugzilla
#

```


**use adoptopenjdk:8-jre-hotspot** success

```bash
pi@raspbian:~$ docker run -p 8080:8080 -p 29418:29418 wang1010q/gitbucket
2020-12-29 02:47:48.789:INFO::main: Logging initialized @547ms to org.eclipse.jetty.util.log.StdErrLog
2020-12-29 02:47:49.110:WARN:oejsh.ContextHandler:main: Empty contextPath
2020-12-29 02:47:49.127:INFO:oejs.Server:main: jetty-9.4.32.v20200930; built: 2020-09-30T16:16:37.804Z; git: de97d26f7bd222a0e16831e353d702a7a422f711; jvm 1.8.0_275-b01
2020-12-29 02:47:53.055:INFO:oejw.StandardDescriptorProcessor:main: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
2020-12-29 02:47:53.970:INFO:oejs.session:main: DefaultSessionIdManager workerName=node0
2020-12-29 02:47:53.971:INFO:oejs.session:main: No SessionScavenger set, using defaults
2020-12-29 02:47:53.982:INFO:oejs.session:main: node0 Scavenging every 600000ms
02:47:56.002 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
02:47:56.859 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
02:47:56.924 [main] WARN  slick.util.AsyncExecutor - Having maxConnection > maxThreads can result in deadlocks if transactions or database locks are used.
02:47:56.980 [main] INFO  g.core.servlet.InitializeListener - Check version
02:47:56.981 [main] INFO  g.core.servlet.InitializeListener - Start schema update
02:48:00.216 [main] INFO  l.servicelocator.ServiceLocator - Can not use class liquibase.parser.core.json.JsonChangeLogParser as a Liquibase service because org.yaml.snakeyaml.constructor.BaseConstructor is not in the classpath
02:48:00.219 [main] INFO  l.servicelocator.ServiceLocator - Can not use class liquibase.parser.core.yaml.YamlChangeLogParser as a Liquibase service because org.yaml.snakeyaml.constructor.BaseConstructor is not in the classpath
02:48:08.262 [main] INFO  g.core.servlet.InitializeListener - Extract bundled plugins...
02:48:08.342 [main] INFO  g.core.servlet.InitializeListener - Extract to /root/.gitbucket/plugins/gitbucket-notifications-plugin-1.9.0.jar
02:48:08.352 [main] INFO  g.core.servlet.InitializeListener - Extract to /root/.gitbucket/plugins/gitbucket-gist-plugin-4.20.0.jar
02:48:08.361 [main] INFO  g.core.servlet.InitializeListener - Extract to /root/.gitbucket/plugins/gitbucket-emoji-plugin-4.6.0.jar
02:48:08.420 [main] INFO  g.core.servlet.InitializeListener - Extract to /root/.gitbucket/plugins/gitbucket-pages-plugin-1.9.0.jar
02:48:08.423 [main] INFO  g.core.servlet.InitializeListener - Initialize plugins
02:48:08.611 [main] INFO  gitbucket.core.plugin.PluginRegistry - Initialize gitbucket-gist-plugin-4.20.0.jar
02:48:09.609 [main] INFO  gitbucket.core.plugin.PluginRegistry - Initialize gitbucket-emoji-plugin-4.6.0.jar
02:48:09.680 [main] INFO  gitbucket.core.plugin.PluginRegistry - Initialize gitbucket-notifications-plugin-1.9.0.jar
02:48:10.033 [main] INFO  gitbucket.core.plugin.PluginRegistry - Initialize gitbucket-pages-plugin-1.9.0.jar
02:48:10.219 [Thread-10] INFO  g.core.plugin.PluginWatchThread - Start PluginWatchThread: /root/.gitbucket/plugins
02:48:10.238 [main] INFO  o.scalatra.servlet.ScalatraListener - The cycle class name from the config: ScalatraBootstrap
02:48:10.248 [main] INFO  o.scalatra.servlet.ScalatraListener - Initializing life cycle class: ScalatraBootstrap
2020-12-29 02:48:12.505:INFO:oejsh.ContextHandler:main: Started o.e.j.w.WebAppContext@56cfe111{/,file:///gitbucket/tmp/webapp/,AVAILABLE}{file:/opt/gitbucket.war}
2020-12-29 02:48:12.543:INFO:oejs.AbstractConnector:main: Started ServerConnector@1c655221{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2020-12-29 02:48:12.556:INFO:oejs.Server:main: Started @24318ms
```