### PR TITLE
Support multi-arch image

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-    tags:        
+    tags:
       - '*'
 
 jobs:
@@ -13,12 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+        uses: actions/checkout@v3      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: gitbucket/gitbucket
-          tag_with_ref: true
-          dockerfile: Dockerfile
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            gitbucket/gitbucket

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3      - name: Set up QEMU
+        uses: actions/checkout@v3
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -27,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             gitbucket/gitbucket

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,13 +39,21 @@ jobs:
       with:
         path: docker
     
-    - name: Build Docker image
-      run: |
-        mv gitbucket/target/executable/gitbucket.war docker/gitbucket.war
-        cd docker
-        docker build . --file Dockerfile-nightly --tag gitbucket/gitbucket:nightly
-        
-    - name: Push Docker image to Docker Hub
-      run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-        docker push gitbucket/gitbucket:nightly
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile-nightly
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          gitbucket/gitbucket:nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM adoptopenjdk:8-jre-hotspot
 
 LABEL maintainer="Naoki Takezoe <takezoe [at] gmail.com>"
 

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -1,8 +1,8 @@
-FROM openjdk:8-jre
+FROM adoptopenjdk:8-jre-hotspot
 
 LABEL maintainer="Naoki Takezoe <takezoe [at] gmail.com>"
 
-ADD gitbucket.war /opt/gitbucket.war
+ADD gitbucket/target/executable/gitbucket.war /opt/gitbucket.war
 
 RUN ln -s /gitbucket /root/.gitbucket
 


### PR DESCRIPTION
In addition to #27

- Resolved conflict with the latest master
- Limit build target to linux/amd64 and linux/arm64
- Support multi-arch image also in nightly build